### PR TITLE
Remove exposed require to allow building with webpack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,6 @@ var Analytics = require('./analytics');
 // Create a new `analytics` singleton.
 var analytics = new Analytics();
 
-// Expose `require`.
-// TODO(ndhoule): Look into deprecating, we no longer need to expose it in tests
-analytics.require = require;
-
 // Expose package version.
 analytics.VERSION = require('../package.json').version;
 


### PR DESCRIPTION
Removing the exposed require allows this library to be used in [SSR] react applications that need a built tool (i.e. webpack)